### PR TITLE
Regrtest summary

### DIFF
--- a/_includes/regrtest_summary.html
+++ b/_includes/regrtest_summary.html
@@ -4,8 +4,9 @@
 {% assign fail_percent = include.fail | times: 100.0 | divided_by: result_total | round: 2 %}
 
 {% assign pass_color = "#4c1" %}
-{% assign skip_color = "#dfb317" %}
+{% assign skip_color = "#e4df12" %}
 {% assign fail_color = "#fe7d37" %}
+{% assign bar_height = "20px" %}
 
 {%if include.svg %}
 
@@ -32,11 +33,11 @@
 
 <div class="tbl padding-small">
   <div class="row">
-    <div class ="cell">
+    <div class ="cell_summary">
         <span class="font-secondary">Total Tests: </span>
         {{ result_total }}
     </div>
-    <div class ="cell">
+    <div class ="cell_summary">
       {% if include.extime %}
       <span class="font-secondary">Exec Time: </span>
       {{ include.extime }}
@@ -45,26 +46,26 @@
     
   </div>
   <div class="row">
-    <div class="cell">
+    <div class="cell_summary">
         <span class="font-secondary">Passed: </span>
         {{ include.pass }} ({{ pass_percent }}%)
     </div>
-    <div class="cell">
+    <div class="cell_summary">
         <span class="font-secondary">Skipped: </span>
         {{ include.skip }} ({{ skip_percent }}%)
     </div>
-    <div class ="cell">
+    <div class ="cell_summary">
         <span class="font-secondary">Failed: </span>
         {{ include.fail }} ({{ fail_percent }}%)
     </div>
   </div>
   <div class="row" 
     style="background: linear-gradient(to right, 
-            green {{ pass_percent }}%, 
-              yellow {{ pass_percent }}% {{ skip_percent | plus: pass_percent }}%, 
-              red {{ skip_percent | plus: pass_percent }}% {{ fail_percent | plus: pass_percent | plus: skip_percent }}%
+              {{ pass_color }} {{ pass_percent }}%, 
+              {{ skip_color }} {{ pass_percent }}% {{ skip_percent | plus: pass_percent }}%, 
+              {{ fail_color }} {{ skip_percent | plus: pass_percent }}% {{ fail_percent | plus: pass_percent | plus: skip_percent }}%
             ); 
-           height: 40px;">
+           height: {{ bar_height }};">
 
   </div>
 </div>

--- a/_includes/regrtest_summary.html
+++ b/_includes/regrtest_summary.html
@@ -36,6 +36,13 @@
         <span class="font-secondary">Total Tests: </span>
         {{ result_total }}
     </div>
+    <div class ="cell">
+      {% if include.extime %}
+      <span class="font-secondary">Exec Time: </span>
+      {{ include.extime }}
+      {% endif %}
+    </div>
+    
   </div>
   <div class="row">
     <div class="cell">

--- a/_includes/regrtest_summary.html
+++ b/_includes/regrtest_summary.html
@@ -20,9 +20,9 @@
       text-rendering="geometricPrecision" font-size="110">
       <text x="255" y="140" transform="scale(.1)"
         textLength="390">Results</text>
-      <text x="805" y="140" transform="scale(.1)" textLength="550">Pass {{ pass_percent }}%</text>
-      <text x="1455" y="140" transform="scale(.1)" textLength="550">Skip {{ skip_percent }}%</text>
-      <text x="2105" y="140" transform="scale(.1)" textLength="550">Fail {{ fail_percent }}%</text>
+      <text x="805" y="140" transform="scale(.1)" textLength="550">Pass {{ pass_percent  | round: 1 }}%</text>
+      <text x="1455" y="140" transform="scale(.1)" textLength="550">Skip {{ skip_percent | round: 1 }}%</text>
+      <text x="2105" y="140" transform="scale(.1)" textLength="550">Fail {{ fail_percent | round: 1 }}%</text>
     </g>
   </svg>
     

--- a/_includes/regrtest_summary.html
+++ b/_includes/regrtest_summary.html
@@ -47,15 +47,15 @@
   <div class="row">
     <div class="cell">
         <span class="font-secondary">Passed: </span>
-        {{ result.num_passed }} ({{ pass_percent }}%)
+        {{ include.pass }} ({{ pass_percent }}%)
     </div>
     <div class="cell">
         <span class="font-secondary">Skipped: </span>
-        {{ result.num_skipped }} ({{ skip_percent }}%)
+        {{ include.skip }} ({{ skip_percent }}%)
     </div>
     <div class ="cell">
         <span class="font-secondary">Failed: </span>
-        {{ result.num_failed }} ({{ fail_percent }}%)
+        {{ include.fail }} ({{ fail_percent }}%)
     </div>
   </div>
   <div class="row" 

--- a/_includes/regrtest_summery.html
+++ b/_includes/regrtest_summery.html
@@ -1,0 +1,64 @@
+{% assign result_total = include.pass | plus: include.skip | plus: include.fail %}
+{% assign pass_percent = include.pass | times: 100.0 | divided_by: result_total | round: 2 %}
+{% assign skip_percent = include.skip | times: 100.0 | divided_by: result_total | round: 2 %}
+{% assign fail_percent = include.fail | times: 100.0 | divided_by: result_total | round: 2 %}
+
+{% assign pass_color = "#4c1" %}
+{% assign skip_color = "#dfb317" %}
+{% assign fail_color = "#fe7d37" %}
+
+{%if include.svg %}
+
+  <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="244" height="20">
+    <g shape-rendering="crispEdges">
+      <rect width="49" height="20" fill="#555" />
+      <rect x="49" width="65" height="20" fill="{{ pass_color }}" />
+      <rect x="114" width="65" height="20" fill="{{ skip_color }}" />
+      <rect x="179" width="65" height="20" fill="{{ fail_color }}" />
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif"
+      text-rendering="geometricPrecision" font-size="110">
+      <text x="255" y="140" transform="scale(.1)"
+        textLength="390">Results</text>
+      <text x="805" y="140" transform="scale(.1)" textLength="550">Pass {{ pass_percent }}%</text>
+      <text x="1455" y="140" transform="scale(.1)" textLength="550">Skip {{ skip_percent }}%</text>
+      <text x="2105" y="140" transform="scale(.1)" textLength="550">Fail {{ fail_percent }}%</text>
+    </g>
+  </svg>
+    
+{% endif %}
+
+{% if include.table or include.svg == nil or include.svg == false %}
+
+<div class="tbl padding-small">
+  <div class="row">
+    <div class ="cell">
+        <span class="font-secondary">Total Tests: </span>
+        {{ result_total }}
+    </div>
+  </div>
+  <div class="row">
+    <div class="cell">
+        <span class="font-secondary">Passed: </span>
+        {{ result.num_passed }} ({{ pass_percent }}%)
+    </div>
+    <div class="cell">
+        <span class="font-secondary">Skipped: </span>
+        {{ result.num_skipped }} ({{ skip_percent }}%)
+    </div>
+    <div class ="cell">
+        <span class="font-secondary">Failed: </span>
+        {{ result.num_failed }} ({{ fail_percent }}%)
+    </div>
+  </div>
+  <div class="row" 
+    style="background: linear-gradient(to right, 
+            green {{ pass_percent }}%, 
+              yellow {{ pass_percent }}% {{ skip_percent | plus: pass_percent }}%, 
+              red {{ skip_percent | plus: pass_percent }}% {{ fail_percent | plus: pass_percent | plus: skip_percent }}%
+            ); 
+           height: 40px;">
+
+  </div>
+</div>
+{% endif %}

--- a/_layouts/regrtests_results.html
+++ b/_layouts/regrtests_results.html
@@ -28,30 +28,42 @@ layout: default
 <div class="w-80 m-auto">
   <div class="m-auto">
     {% for test in site.data.regrtests_results.suites %}
+    
     <div class="results-suites">
       {% for result in test %}
+      
       <div class="results-test">
+        <div class="d-md-flex">
+          <div class="w-md-50">
+            {% if result.module %}
+            <div class="padding-small">
+              <span class="font-secondary">Module:</span>
+              {{result.module }}
+            </div>
+            {% endif %}
 
-        {% if result.module %}
-        <div class="padding-small">
-          <span class="font-secondary">Module:</span>
-          {{result.module }}
-        </div>
-        {% endif %}
+            {% if result.name %}
+            <div class="padding-small">
+              <span class="font-secondary">Name: </span>
+              {{result.name }}
+            </div>
+            {% endif %}
 
-        {% if result.name %}
-        <div class="padding-small">
-          <span class="font-secondary">Name: </span>
-          {{result.name }}
-        </div>
-        {% endif %}
+            {% if result.class %}
+            <div class="padding-small">
+              <span class="font-secondary">Class: </span>
+              {{result.class }}
+            </div>
+            {% endif %}
 
-        {% if result.class %}
-        <div class="padding-small">
-          <span class="font-secondary">Class: </span>
-          {{result.class }}
+            
+          </div>
+          {% if result.num_passed and result.num_skipped and result.num_failed %}
+            <div class="w-md-50 float-md-right">
+              {% include regrtest_summery.html pass=result.num_passed skip=result.num_skipped fail=result.num_failed %}
+            </div>
+          {% endif %}
         </div>
-        {% endif %}
 
         <div class="results-case-wrapper">
           {% for cases in result.cases %}

--- a/_layouts/regrtests_results.html
+++ b/_layouts/regrtests_results.html
@@ -27,6 +27,22 @@ layout: default
 <!--  content -->
 <div class="w-80 m-auto">
   <div class="m-auto">
+
+    <div class="results-suites">
+      <div class="results-test">
+        <div class="padding-small">
+          <h2 class="font-secondary">Summary:</span>
+        </div>
+          {% assign regrtests_results = site.data.regrtests_results %}
+          {% include regrtest_summary.html 
+              pass=regrtests_results.num_passed 
+              skip=regrtests_results.num_skipped 
+              fail=regrtests_results.num_failed 
+              extime=regrtests_results.execution_time
+          %}
+      </div>
+    </div>
+
     {% for test in site.data.regrtests_results.suites %}
     
     <div class="results-suites">
@@ -60,7 +76,7 @@ layout: default
           </div>
           {% if result.num_passed and result.num_skipped and result.num_failed %}
             <div class="w-md-50 float-md-right">
-              {% include regrtest_summery.html pass=result.num_passed skip=result.num_skipped fail=result.num_failed %}
+              {% include regrtest_summary.html pass=result.num_passed skip=result.num_skipped fail=result.num_failed extime=result.execution_time %}
             </div>
           {% endif %}
         </div>

--- a/assets/style.css
+++ b/assets/style.css
@@ -335,3 +335,11 @@ ul.list-inline {
 .filter.active {
     background-color: #FFD43B;
 }
+
+/* classes used in the results summary */
+
+.cell_summary {
+    flex: 4;
+    border-bottom: 1px solid white;
+    align-self: end;
+}


### PR DESCRIPTION
Add summaries for tests to quickly see passed | skipped | failed information

Screenshots:
![image](https://user-images.githubusercontent.com/508861/82963407-09f67b00-9f80-11ea-9482-b1c9d3e9499e.png)

This adds an `include` for a result summary: this `include` can also do a badge like SVG if `svg=true` is passed. but defaults to the table block seen above.

it can do *both* if `svg=true` and `table=true` are passed at the same time.

passing just `table=true` gets you just the table.

![image](https://user-images.githubusercontent.com/508861/82963734-dcf69800-9f80-11ea-8bba-3a0a57292027.png)

I slightly modified the template to allow this include to be added to the right of the head for test groups.
