### PR TITLE
add featured article and create a dashboard box on homepage, fixes #24

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -41,6 +41,10 @@ navigation:
   - title: Gitter
     url: https://gitter.im/rustpython/Lobby
 
+dashboards:
+  - title: CPython test compatibility 
+    url: /pages/regression-tests-results.html
+
 # Build settings
 theme: minima
 plugins:

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -7,13 +7,14 @@ layout: default
 <section>
     <div class="w-100 m-auto mt-2">
         <div class="d-md-flex justify-center">
-            <div class="d-sm-none"><img class="logo" src="{{site.baseurl}}/assets/img/rust-python-logo.svg" alt="RustPython Logo">
+            <div class="d-sm-none"><img class="logo" src="{{site.baseurl}}/assets/img/rust-python-logo.svg"
+                    alt="RustPython Logo">
             </div>
             <div class="w-md-25 pl-2">
                 <div class="title">{{ site.title }}</div>
                 <div class="">
                     <p>
-                       {{ site.description }}
+                        {{ site.description }}
                     </p>
                 </div>
             </div>
@@ -29,14 +30,15 @@ layout: default
     </div>
     <div class="mt-md-4 mt-sm-2 w-md-50 m-auto">
         <p class="mt-md-4">
-          {{ page.explainer }}
+            {{ page.explainer }}
         </p>
     </div>
     <div class="text-md-center">
         <ul class="list-inline">
-          {% for demo in page.demo %}
-            <li class="float-left pr-1 mt-1"><a rel="noopener" rel="noreferrer" href="{{ demo.url }}" target="_blank">{{ demo.label }}</a></li>
-          {% endfor %}
+            {% for demo in page.demo %}
+            <li class="float-left pr-1 mt-1"><a rel="noopener" rel="noreferrer" href="{{ demo.url }}"
+                    target="_blank">{{ demo.label }}</a></li>
+            {% endfor %}
         </ul>
     </div>
 </section>
@@ -47,9 +49,10 @@ layout: default
     <div class="text-center">
         <div class="section-title"> Installation</div>
         {% for install in page.installation %}
-          <mark class="code d-table m-auto mt-1"> {{ install.command }} </mark>
+        <mark class="code d-table m-auto mt-1"> {{ install.command }} </mark>
         {% endfor %}
-        <div class="mt-1"> <small><a rel="noopener" rel="noreferrer" href="{{ page.build-from-source-link }}" target="_blank">OR BUILD FROM SOURCE</a> </small></div>
+        <div class="mt-1"> <small><a rel="noopener" rel="noreferrer" href="{{ page.build-from-source-link }}"
+                    target="_blank">OR BUILD FROM SOURCE</a> </small></div>
     </div>
 </section>
 
@@ -61,28 +64,37 @@ layout: default
         <div class="d-md-flex ">
             {% for goals in page.goals %}
             <div class="w-md-50 mt-2 goal bg-rust">
-              <div class=" text-white p-2">
+                <div class=" text-white p-2">
                     {{ goals.goal }}
-              </div>
+                </div>
             </div>
             {% endfor %}
         </div>
         <div class="d-md-flex  mt-2">
             <div class="w-md-50">
-                 {{ content }}
+                {{ content }}
             </div>
             <div class="w-md-50 mt-2">
                 <div class="border w-md-50 float-md-right mt-md-4 p-2">
-                        <strong> Learn more </strong>
-                        <!-- list of posts where category is "featured" -->
-                        <ul class="list-unstyled">
-                            {%- for post in site.posts -%}
-                              {% if post.categories contains "featured" %}
-                                <li class="mt-1"> <a  href="{{ post.url | relative_url }}">   {{ post.title | escape }} </a></li>
-                              {% endif %}
-                            {%- endfor -%}
-                        </ul>
+                    <strong> Featured Posts </strong>
+                    <!-- list of posts where category is "featured" -->
+                    <ul class="list-unstyled">
+                        {%- for post in site.categories.featured limit:3 -%}
+                        <li class="mt-1"> <a href="{{ post.url | relative_url }}"> {{ post.title | escape }} </a></li>
+                        {%- endfor -%}
+                    </ul>
                 </div>
+
+                <div class="border w-md-50 float-md-right mt-md-4 p-2">
+                    <strong> Dashboard </strong>
+                    <!-- list of posts where category is "featured" -->
+                    <ul class="list-unstyled">
+                        {%- for dashboard in site.dashboards -%}
+                        <li class="mt-1"> <a href="{{ dashboard.url | relative_url }}"> {{ dashboard.title | escape }} </a></li>
+                        {%- endfor -%}
+                    </ul>
+                </div>
+
             </div>
         </div>
     </div>
@@ -96,12 +108,15 @@ layout: default
         <p class="w-80">{{ site.contributor_excerpt}}</p>
         <ul class="list-contributors">
             {% for contributor in site.data.contributors %}
-                <li><a rel="noopener" rel="noreferrer" href="https://github.com/{{ contributor.github_username }}" target="_blank">{{ contributor.github_username }}</a></li>
+            <li><a rel="noopener" rel="noreferrer" href="https://github.com/{{ contributor.github_username }}"
+                    target="_blank">{{ contributor.github_username }}</a></li>
             {% endfor %}
         </ul>
         <div class="d-md-flex">
-          <div class="pr-1 mt-1"><small><a href="https://github.com/RustPython/RustPython/graphs/contributors">VIEW MORE</a></small></div>
-          <div class="mt-1"><small><a href="https://github.com/RustPython/RustPython/#contributing">HOW TO CONTRIBUTE</a></small></div>
+            <div class="pr-1 mt-1"><small><a href="https://github.com/RustPython/RustPython/graphs/contributors">VIEW
+                        MORE</a></small></div>
+            <div class="mt-1"><small><a href="https://github.com/RustPython/RustPython/#contributing">HOW TO
+                        CONTRIBUTE</a></small></div>
         </div>
     </div>
 </section>

--- a/_posts/2020-04-05-how-to-contribute-by-cpython-unittest.markdown
+++ b/_posts/2020-04-05-how-to-contribute-by-cpython-unittest.markdown
@@ -2,7 +2,7 @@
 layout: post
 title:  "How to contribute to RustPython by CPython unittest"
 date:   2020-04-05 01:45:00 +0900
-categories: guideline
+categories: guideline, featured
 ---
 
 At the very end of 2019, we finally reached one of the short-term goals: CPython unittest support. Due to this enhancement, finding CPython compatibility is easier than before.

--- a/index.markdown
+++ b/index.markdown
@@ -39,7 +39,3 @@ IronPython is well-integrated with .NET, which means IronPython can use the .NET
 We want to unlock the same possibilities that Jython and IronPython enable, but for the Rust programming language. In addition, thanks to Rusts' minimal runtime, we're able to compile RustPython to WebAssembly and allow users to run their Python code easily in the browser.
 
 Check the "learn more" section for an explainer of all those jargon-y words, or read the blog for more in-depth technical discussion.
-
-### Other Resources
-
-- [CPython test compatibility]({% link pages/regression-tests-results.markdown %})


### PR DESCRIPTION
Currently the homepage has nothing under "learn more" and the dashboard-y thing for `CPython compatibility` is at the end of a long text.

This PR re-arranges the content, so it looks like this:
![Screenshot from 2020-11-06 12-35-37](https://user-images.githubusercontent.com/521705/98396984-a000f800-202c-11eb-8ed0-e60324482c26.png)

The content is generated by:
- checking posts with a `featured` category for the featured box. I set a limit of 3 (optimism 101)
- reading from the `_configh.yml` file for whatever other dashboard pages we might build 

```
dashboards:
  - title: CPython test compatibility 
    url: /pages/regression-tests-results.html
```
