### PR TITLE
add link to notebook

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -16,6 +16,8 @@ demo:
    label: 'Hello World!'
  - url: "https://rustpython.github.io/demo/"
    label: 'Online demo running on WebAssembly'
+ - url: "https://rustpython.github.io/demo/notebook"
+   label: 'Notebook'
 
 installation:
   - command: "cargo install rustpython"


### PR DESCRIPTION
This PR adds a link to the notebook on the homepage next to the WebAssembly demo. 🥳 

<img width="841" alt="Screen Shot 2020-12-16 at 10 32 13 AM" src="https://user-images.githubusercontent.com/521705/102369707-41635e00-3f8a-11eb-9729-c42ff8f913c9.png">