### PR TITLE
Stylesheet updates for the regression test results 

### DIFF
--- a/_layouts/regrtests_results.html
+++ b/_layouts/regrtests_results.html
@@ -22,6 +22,7 @@ layout: default
     <div data-filter="skipped" class="filter pr-2"> Skipped </div>
     <div data-filter="expected_failure" class="filter pr-2"> Expected Failures </div>
     <div data-filter="" class="filter ml-auto"> Summary only </div>
+    <div class="filter"><a target="_blank" class="text-decoration-none" href="https://github.com/RustPython/rustpython.github.io/blob/master/_data/regrtests_results.json">Json file</a></div>
   </div>
 </div>
 
@@ -31,8 +32,8 @@ layout: default
   <div class="m-auto">
 
     <div class="results-suites">
-      <div class="results-test">
-        <div class="padding-small">
+      <div class="results-test ">
+        <div class="padding-small bg-rust text-white">
           <h2 class="font-secondary">Summary:</span>
         </div>
           {% assign regrtests_results = site.data.regrtests_results %}
@@ -49,9 +50,9 @@ layout: default
     
     <div class="results-suites">
       {% for result in test %}
-      
+     
       <div class="results-test">
-        <div class="d-md-flex">
+        <div class="results-test-header d-md-flex">
           <div class="w-md-50">
             {% if result.module %}
             <div class="padding-small">

--- a/assets/style.css
+++ b/assets/style.css
@@ -54,6 +54,10 @@ h6 {
   text-transform: uppercase;
 }
 
+.text-decoration-none {
+  text-decoration: none;
+}
+
 h1 {
   font-size: 1.5em;
   margin-top: 2em;
@@ -289,11 +293,15 @@ ul.list-inline {
 
 /* test results */
 
+.results-test-header {
+  background-color: #f8f8f8;
+}
+
 .results-test {
   margin-top: 50px;
-  color: #fff;
+  color: #000;
+  border: 1px solid black;
   font-size: 1.1rem;
-  background-color: #f74c00;
   word-wrap: anywhere;
 }
 
@@ -303,15 +311,7 @@ ul.list-inline {
   text-transform: capitalize;
 }
 
-.results-case-wrapper > div {
-  padding-left: 10px;
-  padding-right: 10px;
-}
-
 .results-case {
-  background-color: white;
-  border-left: 1px solid #000;
-  border-right: 1px solid #000;
   pointer-events: auto;
 }
 


### PR DESCRIPTION
This PR is for the Regression test results on [this link ](https://rustpython.github.io/pages/regression-tests-results.html )

- I added "Json file" next to summary view, because the UI is that great and it will be neat to be able to just download the json (or know that it exists)
- I changed the background colors to a muted gray, so it is less jarring. We have now orange on green on yellow on orange again ;p 

### Screenshots


<img width="1128" alt="Screen Shot 2021-03-19 at 12 29 20 PM" src="https://user-images.githubusercontent.com/521705/111826823-c4a88e80-88ae-11eb-9489-48ca99a98c80.png">

<hr>

**Before:**  
<img width="1164" alt="Screen Shot 2021-03-19 at 12 14 44 PM" src="https://user-images.githubusercontent.com/521705/111826222-08e75f00-88ae-11eb-9f63-23b93a6f5fcf.png">

**After:**  
<img width="1157" alt="Screen Shot 2021-03-19 at 12 14 30 PM" src="https://user-images.githubusercontent.com/521705/111826232-0dac1300-88ae-11eb-9e3d-c62c1665205e.png">
