### PR TITLE
links on homepage for benchmarks / what's left

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -47,8 +47,10 @@ navigation:
 dashboards:
   - title: CPython test compatibility 
     url: /pages/regression-tests-results.html
-  - title: What's left to add to RustPython
+  - title: What's left
     url: /pages/whats-left
+  - title: Benchmarks
+    url: /benchmarks
 
 # Build settings
 theme: minima


### PR DESCRIPTION
This PR adds links to the homepage in the dashboard section to:

- What's left: https://rustpython.github.io/pages/whats-left
- Benchmarks: https://rustpython.github.io/benchmarks

<img width="461" alt="Screen Shot 2021-10-25 at 9 40 01 AM" src="https://user-images.githubusercontent.com/521705/138706516-d1235882-3f94-4444-91cb-725ad9949316.png">

