### PR TITLE
add plausible analytics, closes #22

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -51,6 +51,8 @@ dashboards:
     url: /pages/whats-left
   - title: Benchmarks
     url: /benchmarks
+  - title: Website Analytics
+    url: https://plausible.io/rustpython.github.io
 
 # Build settings
 theme: minima

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,7 +11,7 @@
   <link defer async rel="stylesheet" href="{{ "/assets/style.css" | relative_url }}">
   <link defer async rel="stylesheet" href="{{ "/assets/media.css" | relative_url }}">
   <link defer async rel="stylesheet" href="{{ "/assets/github.css" | relative_url }}">
- 
+
   <!-- webmanifest -->
   <link rel="manifest" href="{{site.baseurl}}/manifest.webmanifest">
 
@@ -21,7 +21,8 @@
   <link rel="apple-touch-icon" href="{{site.baseurl}}/assets/apple-touch-icon.png">
 
   {%- feed_meta -%}
-  {%- if jekyll.environment == 'production' and site.google_analytics -%}
-    {%- include google-analytics.html -%}
-  {%- endif -%}
+
+  <!--  plausible analytics -->
+  <script defer data-domain="rustpython.github.io" src="https://plausible.io/js/plausible.js"></script>
+
 </head>


### PR DESCRIPTION
- add plausible analytics script tag
- add link on the homepage to the public analytics dashboard