### PR TITLE
remove reference to non-existent section, fixes #47

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -58,5 +58,3 @@ Each of these implementations offer some benefits: Jython, for example, compiles
 IronPython is well-integrated with .NET, which means IronPython can use the .NET framework and Python 2 libraries or vice versa.
 
 We want to unlock the same possibilities that Jython and IronPython enable, but for the Rust programming language. In addition, thanks to Rusts' minimal runtime, we're able to compile RustPython to WebAssembly and allow users to run their Python code easily in the browser.
-
-Check out the "learn more" section for an explainer of all those jargon-y words, or read the blog for more in-depth technical discussion.


### PR DESCRIPTION
There is no "learn-more" section as mentioned in issue #47 . This PR is to remove a reference to it on homepage.