### PR TITLE
Align installation instructions with RustPython's README

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -20,7 +20,7 @@ demo:
    label: 'Notebook'
 
 installation:
-  - command: "cargo install rustpython"
+  - command: "cargo install --git https://github.com/RustPython/RustPython"
   - command: "wapm install rustpython"
   - command: "conda install rustpython -c conda-forge"
 


### PR DESCRIPTION
The current `cargo install rustpython` was outdated.