### PR TITLE
benchmarks: Hide `data/` folder

### DIFF
--- a/_layouts/benchmarks.html
+++ b/_layouts/benchmarks.html
@@ -25,12 +25,16 @@ layout: default
     {% assign folders = "" | split: ", " %}
     {% for folder in site.static_files %}
         {% if folder.path contains 'criterion/' %}
+        {% unless folder.path contains 'criterion/data/' %}
             {% assign temp = folder.path | split: 'criterion/' %}
-            {% assign pathName = temp[1] | split: '/' | first %}
-            {% assign pathName = pathName | split: ", " %}
-            {% assign folders = folders | concat: pathName %}
+            {% assign directoryName = temp[1] | split: '/' | first %}
+            {% assign pathName = 'criterion/' | append: directoryName %}
+            {% assign pathNameArray = pathName | split: ", " %}
+            {% assign folders = folders | concat: pathNameArray %}
+        {% endunless %}
         {% endif %}
-    {% endfor%}
+    {% endfor %}
+    {% comment %}folders = ['criterion/execution', 'criterion/microbenchmarks', ...]{% endcomment %}
     {% assign folders = folders | uniq %}
 
     {% if folders.size == 0 %}
@@ -41,7 +45,7 @@ layout: default
     <ul class="tab" data-tab="benchmarks">
         {% for folder in folders %}
         <li {% if forloop.index==1 %} class="active" {% endif %} style="font-weight: bold;">
-            <a href="">{{ folder }}</a>
+            <a href="">{{ folder | split: '/' | last }}</a>
         </li>
         {% endfor%}
     </ul>


### PR DESCRIPTION
The `data/` folder contains raw data.

It should not be displayed in the tabs, and its `*.cbor` files should not be rendered

![Capture d'écran 2024-02-25 020632](https://github.com/RustPython/rustpython.github.io/assets/16977446/b5960324-432e-46dc-ba98-b5f3a4367a65)

Implementation:
- Previously we were listing the directory names to use
- Now I'm listing `criterion/<directory>`

Alternatively I can continue listing the directory names, but then I should exclude the `.cbor` files, which will lead to far more false-positive files.

Fixes #66 

This Pull Request was made possible thanks to #67 (thanks @olivierlemasle)

- I do not like liquid template engine, it feels like so much things are missing (using `| split: ", "` to create an array ?!, error with `concat` on line 29 while there is no `concat` on this line ?!, I used an inexistant `spit` filter and the engine did not report it to me ?!)
- feel free to discuss the changes
- looks like we are not using version 5 so I cannot use `liquid` tag https://shopify.github.io/liquid/tags/template/#liquid