### PR TITLE
Rename column name as 'module' in modules.csv

### DIFF
--- a/_data/whats_left/modules.csv
+++ b/_data/whats_left/modules.csv
@@ -1,3 +1,4 @@
+module
 _abc
 _aix_support
 _android_support


### PR DESCRIPTION
It resolves #79. You can see https://moreal.github.io/rustpython.github.io/pages/whats-left to see build output.

<details>

<summary>How to debug</summary>

I installed ruby and dependencies:

ref:
- https://asdf-vm.com/
- https://pages.github.com/versions/
- https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll

```
asdf plugin add ruby https://github.com/asdf-vm/asdf-ruby
asdf install ruby 3.3.4
bundle install
bundle add webrick

bundle exec jekyll serve
```

And when I see the variable by using `{{ var | debug }}`, It was `{"_abc"=>"modulename"}` not `{"module"=>"modulename"}`.
</details>