### PR TITLE
Fix broken development guide link

### DIFF
--- a/_posts/2020-04-05-how-to-contribute-by-cpython-unittest.markdown
+++ b/_posts/2020-04-05-how-to-contribute-by-cpython-unittest.markdown
@@ -63,4 +63,4 @@ def ...  # failed tests
 ```
 
 ## Development guide
-For a general introduction to RustPython development, please visit the [RustPython development guide](https://github.com/RustPython/RustPython/blob/master/DEVELOPMENT.md)
+For a general introduction to RustPython development, please visit the [RustPython development guide](https://github.com/RustPython/RustPython/blob/master/CONTRIBUTING.md#rustpython-development-guide-and-tips)


### PR DESCRIPTION
`DEVELOPMENT.md` was renamed into `CONTRIBUTING.md` in [RustPython@fc637a155](https://github.com/RustPython/RustPython/commit/fc637a155d597c76d2fe458ac47d6a145708f7f4).

This broke the [RustPython development guide link in the CPython unittest contribution blog post](https://rustpython.github.io/blog/2020/04/04/how-to-contribute-by-cpython-unittest.html#:~:text=RustPython%20development%20guide).

### AI usage

Codex 5.5 Extra High: English translation of the PR description.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated a development guide link in a post to point to the current contribution guidelines page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->